### PR TITLE
fix(agent): send X-Agent-ID for sandbox user sync

### DIFF
--- a/internal/agentmode/client.go
+++ b/internal/agentmode/client.go
@@ -22,6 +22,7 @@ type ClientOptions struct {
 	Timeout            time.Duration
 	InsecureSkipVerify bool
 	UserAgent          string
+	AgentID            string
 }
 
 // Client issues authenticated requests against the controller.
@@ -30,6 +31,7 @@ type Client struct {
 	token     string
 	http      *http.Client
 	userAgent string
+	agentID   string
 }
 
 // NewClient constructs a client for the provided controller URL and token.
@@ -79,12 +81,13 @@ func NewClient(baseURL, token string, opts ClientOptions) (*Client, error) {
 		token:     token,
 		http:      client,
 		userAgent: userAgent,
+		agentID:   strings.TrimSpace(opts.AgentID),
 	}, nil
 }
 
 // ListClients fetches the current set of Xray clients from the controller.
 func (c *Client) ListClients(ctx context.Context) (agentproto.ClientListResponse, error) {
-	paths := []string{"/api/agent-server/v1/users"}
+	paths := []string{"/api/agent-server/v1/users", "/api/agent/v1/users"}
 	var lastErr error
 
 	for _, path := range paths {
@@ -139,7 +142,7 @@ func (c *Client) ReportStatus(ctx context.Context, report agentproto.StatusRepor
 		return fmt.Errorf("encode status report: %w", err)
 	}
 
-	paths := []string{"/api/agent-server/v1/status"}
+	paths := []string{"/api/agent-server/v1/status", "/api/agent/v1/status"}
 	var lastErr error
 
 	for _, path := range paths {
@@ -185,5 +188,8 @@ func (c *Client) ReportStatus(ctx context.Context, report agentproto.StatusRepor
 func (c *Client) applyHeaders(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("X-Service-Token", c.token)
+	if c.agentID != "" {
+		req.Header.Set("X-Agent-ID", c.agentID)
+	}
 	req.Header.Set("User-Agent", c.userAgent)
 }

--- a/internal/agentmode/client.go
+++ b/internal/agentmode/client.go
@@ -87,7 +87,7 @@ func NewClient(baseURL, token string, opts ClientOptions) (*Client, error) {
 
 // ListClients fetches the current set of Xray clients from the controller.
 func (c *Client) ListClients(ctx context.Context) (agentproto.ClientListResponse, error) {
-	paths := []string{"/api/agent-server/v1/users", "/api/agent/v1/users"}
+	paths := []string{"/api/agent-server/v1/users"}
 	var lastErr error
 
 	for _, path := range paths {
@@ -142,7 +142,7 @@ func (c *Client) ReportStatus(ctx context.Context, report agentproto.StatusRepor
 		return fmt.Errorf("encode status report: %w", err)
 	}
 
-	paths := []string{"/api/agent-server/v1/status", "/api/agent/v1/status"}
+	paths := []string{"/api/agent-server/v1/status"}
 	var lastErr error
 
 	for _, path := range paths {

--- a/internal/agentmode/runner.go
+++ b/internal/agentmode/runner.go
@@ -65,6 +65,7 @@ func Run(ctx context.Context, opts Options) error {
 		Timeout:            httpTimeout,
 		InsecureSkipVerify: opts.Agent.TLS.InsecureSkipVerify,
 		UserAgent:          buildUserAgent(opts.Agent.ID),
+		AgentID:            opts.Agent.ID,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Scope:\n- Ensure agent sends X-Agent-ID so controller can resolve per-node sandbox binding when using shared token auth.\n\nRisk:\n- Adds X-Agent-ID header; should be ignored by controllers that do not use it.\n\nTests:\n- go test ./...\n\nRollback:\n- revert 8d97c13 and a0095d4\n