### PR TITLE
chore(control-plane): scaffold agent billing hooks and exporter deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Service Plus
 
-`agent.svc.plus` is the lightweight runtime agent for the Cloud Neutral Toolkit. It manages Xray instances on Virtual Machines (VMs), handling configuration synchronization, traffic reporting, and certificate management via Caddy.
+`agent.svc.plus` is the lightweight runtime control agent for the Cloud Neutral Toolkit. It manages Xray instances on Virtual Machines (VMs), handling configuration synchronization, control-plane job scheduling, and certificate management via Caddy. Traffic metric translation and billing remain separate concerns.
 
 ## Features
 
@@ -8,6 +8,7 @@
 *   **Xray Management**: Automatically configures and reloads Xray (XHTTP & TCP modes).
 *   **Secure Communication**: Authenticated synchronization with `accounts.svc.plus`.
 *   **Automated TLS**: Integrated with Caddy for automatic HTTPS/Certificates.
+*   **Control Plane Hooks**: Reconciliation and future autoscaling actions can be triggered from the agent without making it the billing source of truth.
 
 ## 🚀 Quick Start (One-Shell)
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -35,9 +35,10 @@ func main() {
 	logger.Info("starting agent", "id", cfg.Agent.ID)
 
 	opts := agentmode.Options{
-		Logger: logger,
-		Agent:  cfg.Agent,
-		Xray:   cfg.Xray,
+		Logger:  logger,
+		Agent:   cfg.Agent,
+		Xray:    cfg.Xray,
+		Billing: cfg.Billing,
 	}
 
 	if err := agentmode.Run(ctx, opts); err != nil {

--- a/deploy/ansible/playbooks/deploy_agent_svc_plus.yml
+++ b/deploy/ansible/playbooks/deploy_agent_svc_plus.yml
@@ -69,3 +69,23 @@
           - "'active (running)' in service_status.stdout"
         fail_msg: "Agent service is not running"
         success_msg: "Agent service is running"
+
+    - name: Get xray-exporter service status
+      ansible.builtin.command: systemctl status {{ xray_exporter_service_name }}
+      register: exporter_service_status
+      changed_when: false
+      ignore_errors: true
+      when: xray_exporter_enabled
+
+    - name: Display xray-exporter service status
+      ansible.builtin.debug:
+        var: exporter_service_status.stdout_lines
+      when: xray_exporter_enabled
+
+    - name: Verify xray-exporter is running
+      ansible.builtin.assert:
+        that:
+          - "'active (running)' in exporter_service_status.stdout"
+        fail_msg: "xray-exporter service is not running"
+        success_msg: "xray-exporter service is running"
+      when: xray_exporter_enabled

--- a/deploy/ansible/roles/agent_svc_plus/defaults/main.yml
+++ b/deploy/ansible/roles/agent_svc_plus/defaults/main.yml
@@ -19,6 +19,10 @@ agent_svc_plus_data_dir: "/opt/agent.svc.plus"
 
 # Agent configuration
 agent_id: "us-xhttp.svc.plus"
+agent_node_id: "{{ agent_id }}"
+agent_region: ""
+agent_line_code: ""
+agent_pricing_group: ""
 agent_controller_url: "https://accounts-svc-plus-266500572462.asia-northeast1.run.app"
 agent_api_token: ""
 agent_http_timeout: "15s"
@@ -32,6 +36,30 @@ xray_sync_interval: "5m"
 xray_config_path: "/usr/local/etc/xray/config.json"
 xray_tcp_config_path: "/usr/local/etc/xray/tcp-config.json"
 xray_template_dir: "/usr/local/etc/xray/templates"
+
+# Billing / reconciliation configuration
+billing_enabled: false
+billing_service_base_url: ""
+billing_http_timeout: "15s"
+billing_collect_interval: "1m"
+billing_reconcile_interval: "5m"
+
+# Xray exporter deployment (co-deployed with agent playbook)
+xray_exporter_enabled: true
+xray_exporter_binary_name: "xray-exporter"
+xray_exporter_binary_path: "/usr/local/bin/{{ xray_exporter_binary_name }}"
+xray_exporter_binary_src: "{{ lookup('ansible.builtin.env', 'XRAY_EXPORTER_BINARY_SRC') }}"
+xray_exporter_service_name: "xray-exporter"
+xray_exporter_config_dir: "/etc/xray-exporter"
+xray_exporter_config_path: "{{ xray_exporter_config_dir }}/xray-exporter.env"
+xray_exporter_stats_url: "http://127.0.0.1:10085/debug/vars"
+xray_exporter_stats_token: ""
+xray_exporter_accounts_base_url: "{{ agent_controller_url }}"
+xray_exporter_internal_service_token: "{{ agent_api_token }}"
+xray_exporter_node_id: "{{ agent_node_id }}"
+xray_exporter_env: "prod"
+xray_exporter_scrape_interval: "1m"
+xray_exporter_listen_addr: "127.0.0.1:9108"
 
 # Log configuration
 agent_log_level: "info"

--- a/deploy/ansible/roles/agent_svc_plus/handlers/main.yml
+++ b/deploy/ansible/roles/agent_svc_plus/handlers/main.yml
@@ -9,3 +9,9 @@
   ansible.builtin.systemd:
     name: "{{ agent_svc_plus_service_name }}"
     state: reloaded
+
+- name: Restart xray-exporter
+  ansible.builtin.systemd:
+    name: "{{ xray_exporter_service_name }}"
+    state: restarted
+    daemon_reload: true

--- a/deploy/ansible/roles/agent_svc_plus/tasks/main.yml
+++ b/deploy/ansible/roles/agent_svc_plus/tasks/main.yml
@@ -10,6 +10,7 @@
     - "{{ agent_svc_plus_config_dir }}"
     - "{{ agent_svc_plus_data_dir }}"
     - "{{ xray_template_dir }}"
+    - "{{ xray_exporter_config_dir }}"
 
 - name: Deploy agent binary
   ansible.builtin.copy:
@@ -56,9 +57,54 @@
     mode: "0644"
   notify: Restart agent-svc-plus
 
+- name: Ensure xray-exporter binary source is provided when enabled
+  ansible.builtin.assert:
+    that:
+      - xray_exporter_binary_src | length > 0
+    fail_msg: "XRAY_EXPORTER_BINARY_SRC must point to a built xray-exporter binary when xray_exporter_enabled=true."
+  when: xray_exporter_enabled
+
+- name: Deploy xray-exporter binary
+  ansible.builtin.copy:
+    src: "{{ xray_exporter_binary_src }}"
+    dest: "{{ xray_exporter_binary_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart xray-exporter
+  when: xray_exporter_enabled
+
+- name: Deploy xray-exporter environment
+  ansible.builtin.template:
+    src: xray-exporter.env.j2
+    dest: "{{ xray_exporter_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart xray-exporter
+  when: xray_exporter_enabled
+
+- name: Deploy xray-exporter systemd service unit
+  ansible.builtin.template:
+    src: xray-exporter.service.j2
+    dest: "/etc/systemd/system/{{ xray_exporter_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart xray-exporter
+  when: xray_exporter_enabled
+
 - name: Enable and start agent-svc-plus
   ansible.builtin.systemd:
     name: "{{ agent_svc_plus_service_name }}"
     enabled: true
     state: started
     daemon_reload: true
+
+- name: Enable and start xray-exporter
+  ansible.builtin.systemd:
+    name: "{{ xray_exporter_service_name }}"
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: xray_exporter_enabled

--- a/deploy/ansible/roles/agent_svc_plus/templates/agent-config.yaml.j2
+++ b/deploy/ansible/roles/agent_svc_plus/templates/agent-config.yaml.j2
@@ -5,6 +5,10 @@ log:
 
 agent:
   id: "{{ agent_id }}"
+  nodeId: "{{ agent_node_id }}"
+  region: "{{ agent_region }}"
+  lineCode: "{{ agent_line_code }}"
+  pricingGroup: "{{ agent_pricing_group }}"
   controllerUrl: "{{ agent_controller_url }}"
   apiToken: "{{ agent_api_token }}"
   httpTimeout: {{ agent_http_timeout }}
@@ -12,6 +16,13 @@ agent:
   syncInterval: {{ agent_sync_interval }}
   tls:
     insecureSkipVerify: {{ agent_tls_insecure_skip_verify | lower }}
+
+billing:
+  enabled: {{ billing_enabled | lower }}
+  baseURL: "{{ billing_service_base_url }}"
+  httpTimeout: {{ billing_http_timeout }}
+  collectInterval: {{ billing_collect_interval }}
+  reconcileInterval: {{ billing_reconcile_interval }}
 
 {% if xray_enabled %}
 xray:

--- a/deploy/ansible/roles/agent_svc_plus/templates/xray-exporter.env.j2
+++ b/deploy/ansible/roles/agent_svc_plus/templates/xray-exporter.env.j2
@@ -1,0 +1,8 @@
+XRAY_STATS_URL={{ xray_exporter_stats_url }}
+XRAY_STATS_TOKEN={{ xray_exporter_stats_token }}
+ACCOUNTS_BASE_URL={{ xray_exporter_accounts_base_url }}
+INTERNAL_SERVICE_TOKEN={{ xray_exporter_internal_service_token }}
+EXPORTER_NODE_ID={{ xray_exporter_node_id }}
+EXPORTER_ENV={{ xray_exporter_env }}
+SCRAPE_INTERVAL={{ xray_exporter_scrape_interval }}
+LISTEN_ADDR={{ xray_exporter_listen_addr }}

--- a/deploy/ansible/roles/agent_svc_plus/templates/xray-exporter.service.j2
+++ b/deploy/ansible/roles/agent_svc_plus/templates/xray-exporter.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Xray Exporter
+After=network.target xray.service
+
+[Service]
+EnvironmentFile={{ xray_exporter_config_path }}
+ExecStart={{ xray_exporter_binary_path }}
+Restart=always
+User=root
+WorkingDirectory={{ agent_svc_plus_data_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/architecture/proxy-server/overview.md
+++ b/docs/architecture/proxy-server/overview.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-`agent.svc.plus` is the lightweight runtime agent that runs on a VM. It is not a traditional data service; it synchronizes Xray configuration, reports heartbeat/status, and bridges the node to `accounts.svc.plus`.
+`agent.svc.plus` is the lightweight runtime control service that runs on a VM. It is not a traditional data service; it synchronizes Xray configuration, reports heartbeat/status, schedules reconciliation jobs, and bridges the node to `accounts.svc.plus`.
 
 ## Architecture
 
@@ -15,8 +15,10 @@ flowchart TB
   Client["agentmode.Client\nHTTP client to controller"]
   Sync["xrayconfig periodic syncers"]
   Xray["xray-core"]
+  Exporter["xray-exporter"]
   Caddy["Caddy / TLS / ACME"]
   Accounts["accounts.svc.plus"]
+  Billing["billing-service"]
   AgentAPI["/api/agent-server/v1/users\n/api/agent-server/v1/status"]
   Edge["Optional Cloudflare Workers / container runtime"]
 
@@ -29,7 +31,10 @@ flowchart TB
   Sync --> Xray
   Sync --> Caddy
   Xray --> Caddy
+  Xray --> Exporter
+  Exporter --> Billing
   AgentAPI --> Accounts
+  Billing --> Accounts
   Edge --> AgentAPI
 ```
 
@@ -48,6 +53,8 @@ flowchart TB
 - Keep TLS certificates live via Caddy.
 - Poll accounts for client and node updates.
 - Report agent health and sync progress back to the controller.
+- Schedule billing reconciliation and future control actions without owning the billing source of truth.
+- Leave traffic metric translation to the separate exporter layer.
 
 ## Data / Storage Notes
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,7 +1,7 @@
 # Agent Service Plus Design & Architecture
 
 ## Overview
-`agent.svc.plus` is a lightweight agent designed to run on a VM (Virtual Machine). It serves as the runtime for Xray, managing connectivity and configuration synchronization with the central `accounts.svc.plus` service.
+`agent.svc.plus` is a lightweight control agent designed to run on a VM (Virtual Machine). It serves as the runtime for Xray, managing connectivity and configuration synchronization with the central `accounts.svc.plus` service while leaving traffic metric translation and billing to separate services.
 
 ## Architecture
 
@@ -13,12 +13,13 @@
 ### Key Components
 
 1.  **Agent (Go Binary)**:
-    *   **Role**: Controller.
+    *   **Role**: Controller / orchestrator.
     *   **Responsibilities**:
         *   Authenticate with `accounts.svc.plus`.
         *   Fetch configuration (UUIDs, Routing rules).
         *   Generate Xray configuration files at `/usr/local/etc/xray/`.
         *   Reload `xray` services (`systemctl reload xray`, `systemctl reload xray-tcp`).
+        *   Schedule reconciliation jobs and future control actions.
 
 2.  **Xray (Proxy)**:
     *   **Mode 1: XHTTP (Split Mode)**:
@@ -34,6 +35,16 @@
     *   Handles ACME (Let's Encrypt/ZeroSSL) automatically.
     *   Reverse proxies `/split/*` to Xray via Unix socket.
 
+4.  **xray-exporter / billing-service (separate control plane utilities)**:
+    *   `xray-exporter` polls raw Xray stats and emits Prometheus metrics.
+    *   `billing-service` consumes minute-level traffic deltas and writes PostgreSQL billing rows.
+    *   `agent` may trigger or observe these jobs, but does not own their data model.
+
+## Acceptance
+
+See `docs/testing/agent-reconciliation-acceptance.md` for the orchestration-only
+acceptance checklist used by CRT-007.
+
 ## Interaction Flow
 
 1.  **Startup**:
@@ -45,7 +56,12 @@
     *   Endpoint: `GET /api/agent/sync` (or `GET /api/agent/config`).
     *   Payload includes: User UUIDs, Traffic limits (optional).
 
-3.  **Reconfiguration**:
+3.  **计费与观测边界**:
+    *   Xray 仅提供原始流量数据。
+    *   exporter 负责指标化，不参与计费。
+    *   PostgreSQL 负责计费真相源。
+
+4.  **Reconfiguration**:
     *   If config changes:
         *   Agent regenerates `config.json` and `tcp-config.json`.
         *   Agent executes reload command.

--- a/docs/testing/agent-reconciliation-acceptance.md
+++ b/docs/testing/agent-reconciliation-acceptance.md
@@ -1,0 +1,65 @@
+# Agent Reconciliation Acceptance
+
+This document defines the execution and acceptance checklist for `agent.svc.plus`
+in the CRT-007 control plane.
+
+## P0 Boundary Freeze
+
+- `agent.svc.plus` is scheduler / reconciler / future autoscaling executor only.
+- `agent.svc.plus` does not own usage or billing truth.
+- `agent.svc.plus` does not read Prometheus as a billing source.
+
+## P1 Scheduling Model
+
+Deliverables:
+
+- periodic trigger for `billing-service` collect-and-rate job
+- periodic trigger for `billing-service` reconcile job
+- retry and warning logs on downstream failure
+
+Acceptance:
+
+- billing collection job can be triggered by ticker
+- reconciliation job can be triggered by ticker
+- downstream HTTP failure does not crash the agent loop
+
+## P2 Observability and Status
+
+Deliverables:
+
+- report last job execution time
+- report last job success time
+- report last job failure message
+- keep orchestration status separate from billing truth
+
+Acceptance:
+
+- status report surfaces recent orchestration activity
+- restart does not fabricate billing state
+
+## P3 Interface Orchestration
+
+Deliverables:
+
+- invoke `POST /v1/jobs/collect-and-rate`
+- invoke `POST /v1/jobs/reconcile`
+- never write `traffic_stat_checkpoints`, `traffic_minute_buckets`, `billing_ledger`, or `account_quota_states` directly
+
+Acceptance:
+
+- all billing writes remain inside `billing-service`
+- agent only coordinates job execution and reports health
+
+## P4 Runtime Validation
+
+Checks:
+
+- ticker triggers job endpoint on schedule
+- retry/backoff path logs warnings and continues
+- restart after missed interval resumes scheduling safely
+- controller outage or billing-service outage leaves agent degraded but running
+
+Suggested verification commands:
+
+- `cd /Users/shenlan/workspaces/cloud-neutral-toolkit/agent.svc.plus && go test ./...`
+- `cd /Users/shenlan/workspaces/cloud-neutral-toolkit/github-org-cloud-neutral-toolkit && rg -n "scheduler|reconciliation|billing-service|does not own billing truth" docs/operations-governance/cross-repo-tasks.md /Users/shenlan/workspaces/cloud-neutral-toolkit/agent.svc.plus/docs`

--- a/internal/agentmode/billing_client.go
+++ b/internal/agentmode/billing_client.go
@@ -1,0 +1,69 @@
+package agentmode
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type BillingClient struct {
+	baseURL *url.URL
+	http    *http.Client
+}
+
+func NewBillingClient(baseURL string, timeout time.Duration) (*BillingClient, error) {
+	trimmedURL := strings.TrimSpace(baseURL)
+	if trimmedURL == "" {
+		return nil, fmt.Errorf("billing base url is required")
+	}
+	parsed, err := url.Parse(trimmedURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse billing base url: %w", err)
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	return &BillingClient{
+		baseURL: parsed,
+		http: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
+}
+
+func (c *BillingClient) TriggerCollectAndRate(ctx context.Context) error {
+	return c.trigger(ctx, "/v1/jobs/collect-and-rate")
+}
+
+func (c *BillingClient) TriggerReconcile(ctx context.Context) error {
+	return c.trigger(ctx, "/v1/jobs/reconcile")
+}
+
+func (c *BillingClient) trigger(ctx context.Context, path string) error {
+	endpoint, err := url.JoinPath(c.baseURL.String(), path)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<14))
+	return fmt.Errorf("billing returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+}

--- a/internal/agentmode/billing_scheduler.go
+++ b/internal/agentmode/billing_scheduler.go
@@ -1,0 +1,64 @@
+package agentmode
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+type billingTriggerer interface {
+	TriggerCollectAndRate(ctx context.Context) error
+	TriggerReconcile(ctx context.Context) error
+}
+
+func startBillingSchedulers(ctx context.Context, client billingTriggerer, cfg billingScheduleConfig, logger *slog.Logger) {
+	if client == nil {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	if cfg.collectInterval > 0 {
+		go runBillingLoop(ctx, cfg.collectInterval, cfg.httpTimeout, logger.With("component", "billing-collect"), client.TriggerCollectAndRate)
+	}
+	if cfg.reconcileInterval > 0 {
+		go runBillingLoop(ctx, cfg.reconcileInterval, cfg.httpTimeout, logger.With("component", "billing-reconcile"), client.TriggerReconcile)
+	}
+}
+
+type billingScheduleConfig struct {
+	httpTimeout       time.Duration
+	collectInterval   time.Duration
+	reconcileInterval time.Duration
+}
+
+func runBillingLoop(ctx context.Context, interval, timeout time.Duration, logger *slog.Logger, trigger func(context.Context) error) {
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+
+	invoke := func() {
+		runCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		if err := trigger(runCtx); err != nil {
+			logger.Warn("billing job trigger failed", "err", err)
+			return
+		}
+		logger.Info("billing job trigger succeeded")
+	}
+
+	invoke()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			invoke()
+		}
+	}
+}

--- a/internal/agentmode/billing_scheduler_test.go
+++ b/internal/agentmode/billing_scheduler_test.go
@@ -1,0 +1,88 @@
+package agentmode
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBillingClientTriggersBothJobs(t *testing.T) {
+	var mu sync.Mutex
+	hits := map[string]int{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits[r.URL.Path]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewBillingClient(server.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("new billing client: %v", err)
+	}
+
+	if err := client.TriggerCollectAndRate(context.Background()); err != nil {
+		t.Fatalf("trigger collect-and-rate: %v", err)
+	}
+	if err := client.TriggerReconcile(context.Background()); err != nil {
+		t.Fatalf("trigger reconcile: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits["/v1/jobs/collect-and-rate"] != 1 {
+		t.Fatalf("expected collect-and-rate hit, got %#v", hits)
+	}
+	if hits["/v1/jobs/reconcile"] != 1 {
+		t.Fatalf("expected reconcile hit, got %#v", hits)
+	}
+}
+
+func TestBillingSchedulerInvokesImmediateJobs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	hits := map[string]int{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits[r.URL.Path]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewBillingClient(server.URL, time.Second)
+	if err != nil {
+		t.Fatalf("new billing client: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	startBillingSchedulers(ctx, client, billingScheduleConfig{
+		httpTimeout:       time.Second,
+		collectInterval:   50 * time.Millisecond,
+		reconcileInterval: 50 * time.Millisecond,
+	}, logger)
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits["/v1/jobs/collect-and-rate"] == 0 {
+		t.Fatalf("expected collect-and-rate to be invoked, got %#v", hits)
+	}
+	if hits["/v1/jobs/reconcile"] == 0 {
+		t.Fatalf("expected reconcile to be invoked, got %#v", hits)
+	}
+}

--- a/internal/agentmode/runner.go
+++ b/internal/agentmode/runner.go
@@ -17,9 +17,10 @@ import (
 
 // Options configures the agent runtime.
 type Options struct {
-	Logger *slog.Logger
-	Agent  config.Agent
-	Xray   config.Xray
+	Logger  *slog.Logger
+	Agent   config.Agent
+	Xray    config.Xray
+	Billing config.Billing
 }
 
 // Run launches the agent mode control loop. It blocks until the context is
@@ -59,6 +60,31 @@ func Run(ctx context.Context, opts Options) error {
 	httpTimeout := opts.Agent.HTTPTimeout
 	if httpTimeout <= 0 {
 		httpTimeout = 15 * time.Second
+	}
+
+	if opts.Billing.Enabled {
+		billingTimeout := opts.Billing.HTTPTimeout
+		if billingTimeout <= 0 {
+			billingTimeout = httpTimeout
+		}
+		collectInterval := opts.Billing.CollectInterval
+		if collectInterval <= 0 {
+			collectInterval = time.Minute
+		}
+		reconcileInterval := opts.Billing.ReconcileInterval
+		if reconcileInterval <= 0 {
+			reconcileInterval = 5 * time.Minute
+		}
+
+		billingClient, err := NewBillingClient(opts.Billing.BaseURL, billingTimeout)
+		if err != nil {
+			return err
+		}
+		startBillingSchedulers(ctx, billingClient, billingScheduleConfig{
+			httpTimeout:       billingTimeout,
+			collectInterval:   collectInterval,
+			reconcileInterval: reconcileInterval,
+		}, logger)
 	}
 
 	client, err := NewClient(controllerURL, token, ClientOptions{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Config struct {
-	Mode  string `yaml:"mode"`
-	Log   Log    `yaml:"log"`
-	Agent Agent  `yaml:"agent"`
-	Xray  Xray   `yaml:"xray"`
+	Mode    string  `yaml:"mode"`
+	Log     Log     `yaml:"log"`
+	Agent   Agent   `yaml:"agent"`
+	Xray    Xray    `yaml:"xray"`
+	Billing Billing `yaml:"billing"`
 }
 
 type Log struct {
@@ -42,6 +43,14 @@ type TLS struct {
 
 type Xray struct {
 	Sync XraySync `yaml:"sync"`
+}
+
+type Billing struct {
+	Enabled           bool          `yaml:"enabled"`
+	BaseURL           string        `yaml:"baseURL"`
+	HTTPTimeout       time.Duration `yaml:"httpTimeout"`
+	CollectInterval   time.Duration `yaml:"collectInterval"`
+	ReconcileInterval time.Duration `yaml:"reconcileInterval"`
 }
 
 type XraySync struct {
@@ -89,6 +98,9 @@ func LoadReader(r io.Reader) (*Config, error) {
 	}
 	if domain := os.Getenv("DOMAIN"); domain != "" {
 		cfg.Agent.Domain = domain
+	}
+	if billingURL := os.Getenv("BILLING_SERVICE_BASE_URL"); billingURL != "" {
+		cfg.Billing.BaseURL = billingURL
 	}
 
 	return &cfg, nil

--- a/scripts/setup-proxy.sh
+++ b/scripts/setup-proxy.sh
@@ -13,6 +13,7 @@ XRAY_TCP_USER="caddy"
 OPEN_STUNNEL_5443="${OPEN_STUNNEL_5443:-false}"
 STANDALONE_MODE=false
 STANDALONE_UUID_FILE="/usr/local/etc/xray/standalone.uuid"
+AGENT_DATA_DIR="${AGENT_DATA_DIR:-/opt/agent.svc.plus}"
 CLOUDFLARE_ZONE_NAME="${CLOUDFLARE_ZONE_NAME:-svc.plus}"
 CLOUDFLARE_API_BASE="https://api.cloudflare.com/client/v4"
 GITHUB_REPO="${GITHUB_REPO:-cloud-neutral-toolkit/agent.svc.plus}"
@@ -767,6 +768,11 @@ systemctl stop caddy || true
 mkdir -p /usr/local/etc/xray
 chown -R root:root /usr/local/etc/xray
 chmod -R a+rX /usr/local/etc/xray
+if [ "$STANDALONE_MODE" != true ]; then
+    mkdir -p "${AGENT_DATA_DIR}"
+    chown root:root "${AGENT_DATA_DIR}"
+    chmod 0755 "${AGENT_DATA_DIR}"
+fi
 # Legacy helper is no longer needed after switching to direct cert paths.
 rm -f /usr/local/bin/sync-agent-certs
 
@@ -854,7 +860,7 @@ After=network.target
 ExecStart=/usr/local/bin/agent-svc-plus -config /etc/agent/account-agent.yaml
 Restart=always
 User=root
-WorkingDirectory=/opt/agent.svc.plus
+WorkingDirectory=${AGENT_DATA_DIR}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Scope
- scaffold agent billing hooks and scheduler integration points
- co-deploy xray-exporter through deploy_agent_svc_plus.yml and agent ansible role
- keep APISIX write actions disabled in this phase

## Risk
- deploy chain now expects xray-exporter binary env input when exporter deployment is enabled
- runtime behavior changes are limited to billing job scaffolding and exporter service deployment

## Tests
- go test ./...

## Rollback
- revert this PR
- disable or stop xray-exporter service on deployed nodes if needed
- keep billing-service and APISIX rollout independent
