### PR TITLE
ci: add gitleaks secret-scan gate to validate-release-pr

### DIFF
--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -1,0 +1,30 @@
+name: Validate Release PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  sec-qa-gate:
+    name: Sec QA Gate (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz" -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: gitea-secrets-vault
+        run: gitleaks detect -v --redact --exit-code 1


### PR DESCRIPTION
## Summary
- Add `.github/workflows/validate-release-pr.yml` (missing on `main`) with a `sec-qa-gate` job that runs gitleaks on PRs.
- The scan step is named `gitea-secrets-vault` and runs `gitleaks detect -v --redact --exit-code 1`, matching the same gate already merged on `main` in sibling repos (e.g. AI-Relay-Kit, accounts.svc.plus, billing-service, postgresql.svc.plus, qmd, codex-plugin-cc).

## Test plan
- [ ] Open a PR against `main` and confirm the `sec-qa-gate` job runs and gitleaks executes.
- [ ] Confirm the job fails a PR that introduces a secret, and passes otherwise.